### PR TITLE
fix registration from other mods

### DIFF
--- a/nodes.lua
+++ b/nodes.lua
@@ -375,7 +375,7 @@ end
 
 function mymillwork.register_all(suffix, model, mdesc, sbox, cbox, node_suffix, material, desc, image, group)
 
-    minetest.register_node("mymillwork:" .. suffix .. "_" .. node_suffix, {
+    minetest.register_node(":mymillwork:" .. suffix .. "_" .. node_suffix, {
     description = desc .. " " .. mdesc,
     drawtype = "mesh",
     mesh = model,


### PR DESCRIPTION
should allow the registration api to be called from other mods. basically what every other mod does. see moreblocks for example https://github.com/minetest-mods/moreblocks/blob/master/stairsplus/common.lua#L179 . should fix/allow https://github.com/mt-mods/dreambuilder_game/commit/3c28bea220569b55b750ad809fcba18dff0305a0 to work